### PR TITLE
Update 'Project - Dev Client' scheme - set buildConfiguration to Debug

### DIFF
--- a/ios/Test1.xcodeproj/xcshareddata/xcschemes/Project - Dev Client.xcscheme
+++ b/ios/Test1.xcodeproj/xcshareddata/xcschemes/Project - Dev Client.xcscheme
@@ -72,7 +72,7 @@
       buildConfiguration = "Debug">
    </AnalyzeAction>
    <ArchiveAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       revealArchiveInOrganizer = "YES">
    </ArchiveAction>
 </Scheme>


### PR DESCRIPTION
This fixes the issue with building the debug scheme with EAS Build.

https://staging.expo.io/accounts/dsokal-adhoc/builds/v2/8fae8818-a430-4e8d-806d-f3e2446ad73e/logs